### PR TITLE
Pe pp2 bugs changes

### DIFF
--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -2491,6 +2491,30 @@ void entity_loadtexturesandeffect ( void )
 					t.entityprofile[t.entid].texsid = t.texuseid;
 					TextureObject(t.entobj, 3, t.entityprofile[t.entid].texsid);
 				}
+				//PE: iEffectProfile != 1 for this type of objects at this point in code.
+				if (t.entityprofile[t.entid].texiid == 0)
+				{
+					if (g.gpbroverride == 1) // iEffectProfile == 1
+					{
+						// if no local CUBE, see if the level has generated one (matches sky and terrain)
+						t.entityprofile[t.entid].texiid = t.terrain.imagestartindex + 31;
+					}
+				}
+				//Not set anywhere, so just use blank_o.
+				t.texuseid = loadinternaltextureex("effectbank\\reloaded\\media\\blank_O.dds", 1, t.tfullorhalfdivide);
+				t.entityprofiletexoid = t.texuseid; // must always be set.
+
+				//PE: PBR shader support for old media with no texture in fpe.
+				if (g.gpbroverride == 1) {
+					//None of the below will be in old media , so setup using fallback textures.
+					t.entityprofile[t.entid].texlid = loadinternaltextureex("effectbank\\reloaded\\media\\detail_default.dds", 1, t.tfullorhalfdivide);
+					t.entityprofile[t.entid].texgid = loadinternaltextureex("effectbank\\reloaded\\media\\white_D.dds", 1, t.tfullorhalfdivide);
+					t.entityprofile[t.entid].texhid = loadinternaltextureex("effectbank\\reloaded\\media\\blank_black.dds", 1, t.tfullorhalfdivide);
+					TextureObject(t.entobj, 8, t.entityprofile[t.entid].texlid);
+					TextureObject(t.entobj, 4, t.entityprofile[t.entid].texgid);
+					TextureObject(t.entobj, 5, t.entityprofile[t.entid].texhid);
+					TextureObject(t.entobj, 7, t.entityprofiletexibrid);
+				}
 
 			}
 

--- a/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
@@ -3294,7 +3294,7 @@ void editor_init ( void )
 	SetObjectTransparency (  t.editor.objectstartindex+5,2 );
 	modifyplaneimagestrip(5,8,1);
 	SetObjectCollisionOff (  t.editor.objectstartindex+5 );
-	DisableObjectZDepth (  t.editor.objectstartindex+5 );
+	//DisableObjectZDepth (  t.editor.objectstartindex+5 ); //PE: UpdateLayerInner layer 4 do not render bNewZLayerObject in pass 0 so is clipped.
 	SetObjectLight (  t.editor.objectstartindex+5,0 );
 	HideObject (  t.editor.objectstartindex+5 );
 	OffsetLimb (  t.editor.objectstartindex+5,0,0,0,-1 );

--- a/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-GridEdit.cpp
@@ -2177,6 +2177,10 @@ void input_getfilemapcontrols ( void )
 			{
 				// When click non-Builder tab, should leave builder mode
 				ebe_hide();
+
+				//PE: If first entity, shader have not yet had constant set , so update shaders.
+				//PE: Prevent new created ebe from disappering when clicking away from "builder".
+				visuals_justshaderupdate();
 			}
 			SetFileMapDWORD (  1, 546, 0 );
 		}

--- a/GameGuru/Files/effectbank/reloaded/decal_animate4.fx
+++ b/GameGuru/Files/effectbank/reloaded/decal_animate4.fx
@@ -113,13 +113,27 @@ vertexOutput mainVS(appdata IN)
 float4 mainPS(vertexOutput IN) : COLOR
 {
    float4 diffuse = DiffuseMap.SampleLevel(SampleWrap,IN.atlasUV,0);
+#ifdef ENABLEDECALALPHACLIP
    if( diffuse.a < 0.42 ) 
    {
       clip(-1);
       return float4(0,0,0,1);
    }
+#endif
    return diffuse;
 }
+
+BlendState DecalAlpha
+{
+	BlendEnable[0] = TRUE;
+	SrcBlend = SRC_ALPHA;
+	DestBlend = INV_SRC_ALPHA;
+	BlendOp = ADD;
+	SrcBlendAlpha = ZERO;
+	DestBlendAlpha = INV_SRC_ALPHA;
+	BlendOpAlpha = ADD;
+	RenderTargetWriteMask[0] = 0x0F; // color write enable all.
+};
 
 technique11 Highest
 {
@@ -128,6 +142,7 @@ technique11 Highest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -138,6 +153,7 @@ technique11 Medium
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -148,26 +164,7 @@ technique11 Lowest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
-//PE: GameGuru Editor crash ? When DepthMap is in the decal shaders ?
-//Not sure what the real reason for this crash is.(thanks cybernescence)
-//technique11 DepthMap
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
-//
-//technique11 DepthMapNoAnim
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
+//PE: technique11 DepthMap removed this has been fixed in c code.

--- a/GameGuru/Files/effectbank/reloaded/decal_animate8.fx
+++ b/GameGuru/Files/effectbank/reloaded/decal_animate8.fx
@@ -113,13 +113,27 @@ vertexOutput mainVS(appdata IN)
 float4 mainPS(vertexOutput IN) : COLOR
 {
    float4 diffuse = DiffuseMap.SampleLevel(SampleWrap,IN.atlasUV,0);
+#ifdef ENABLEDECALALPHACLIP
    if( diffuse.a < 0.42 ) 
    {
       clip(-1);
       return float4(0,0,0,1);
    }
+#endif
    return diffuse;
 }
+
+BlendState DecalAlpha
+{
+	BlendEnable[0] = TRUE;
+	SrcBlend = SRC_ALPHA;
+	DestBlend = INV_SRC_ALPHA;
+	BlendOp = ADD;
+	SrcBlendAlpha = ZERO;
+	DestBlendAlpha = INV_SRC_ALPHA;
+	BlendOpAlpha = ADD;
+	RenderTargetWriteMask[0] = 0x0F; // color write enable all.
+};
 
 technique11 Highest
 {
@@ -128,6 +142,7 @@ technique11 Highest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -138,6 +153,7 @@ technique11 Medium
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -148,26 +164,7 @@ technique11 Lowest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
-//PE: GameGuru Editor crash ? When DepthMap is in the decal shaders ?
-//Not sure what the real reason for this crash is.(thanks cybernescence)
-//technique11 DepthMap
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
-//
-//technique11 DepthMapNoAnim
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
+//PE: technique11 DepthMap removed this has been fixed in c code.

--- a/GameGuru/Files/effectbank/reloaded/decal_basic.fx
+++ b/GameGuru/Files/effectbank/reloaded/decal_basic.fx
@@ -106,9 +106,20 @@ float4 mainPS(vertexOutput IN) : COLOR
     // and Finally add in any Water Fog   
     float4 waterfogresult = lerp(hudfogresult,FogColor,IN.WaterFog);   
     finalcolor=float4(waterfogresult.xyz,alpha);  
-	
     return finalcolor;
 }
+
+BlendState DecalAlpha
+{
+	BlendEnable[0] = TRUE;
+	SrcBlend = SRC_ALPHA;
+	DestBlend = INV_SRC_ALPHA;
+	BlendOp = ADD;
+	SrcBlendAlpha = ZERO;
+	DestBlendAlpha = INV_SRC_ALPHA;
+	BlendOpAlpha = ADD;
+	RenderTargetWriteMask[0] = 0x0F; // color write enable all.
+};
 
 technique11 Highest
 {
@@ -117,6 +128,7 @@ technique11 Highest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -127,6 +139,7 @@ technique11 Medium
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
 
@@ -137,26 +150,7 @@ technique11 Lowest
         SetVertexShader(CompileShader(vs_5_0, mainVS()));
         SetPixelShader(CompileShader(ps_5_0, mainPS()));
         SetGeometryShader(NULL);
+        SetBlendState(DecalAlpha, float4( 0.0f, 0.0f, 0.0f, 0.0f ), 0xFFFFFFFF);
     }
 }
-//PE: GameGuru Editor crash ? When DepthMap is in the decal shaders ?
-//Not sure what the real reason for this crash is.(thanks cybernescence)
-//technique11 DepthMap
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
-//
-//technique11 DepthMapNoAnim
-//{
-//    pass MainPass
-//    {
-//        SetVertexShader(NULL);
-//        SetPixelShader(NULL);
-//        SetGeometryShader(NULL);
-//    }
-//}
+//PE: technique11 DepthMap removed this has been fixed in c code.

--- a/GameGuru/Files/effectbank/reloaded/settings.fx
+++ b/GameGuru/Files/effectbank/reloaded/settings.fx
@@ -65,6 +65,7 @@
 #define MAXFLASHLIGHT (0.975) // PE: max intensity of flashlight 1.0 = 100% , 0.5 = 50%.
 //#define PEROJECTLIGHT // Change per object specular to per object light.
 //#define BOOSTILLUM // Add more light from the illumination texture.
+//#define ENABLEDECALALPHACLIP // Enable old alpha clip on decals , do not look as good as real blending. but are faster.
 
 //Settings used by FXAA-CV-LS
 #define COLORVIBRANCE (0.40)


### PR DESCRIPTION
fix:
https://github.com/TheGameCreators/GameGuruRepo/issues/69
https://github.com/TheGameCreators/GameGuruRepo/issues/53
Added: blending on particle/explosion/decals for better effects.
Removed: alpha clip on particle/explosion/decals , and moved it as a setting #define ENABLEDECALALPHACLIP (disabled by default).
The DX11 blending is way better and should open up for some great effects.
Added: PBR overwrite support for old multi textured models with no texture in fpe.
