### PR TITLE
Pre-compile Lua scripts for standalone (except anything with "multipl…

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Core/DBDLLCore.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Core/DBDLLCore.cpp
@@ -16,6 +16,7 @@
 #include "..\..\..\..\Guru-MapEditor\Encryptor.h"
 #include ".\..\Core\SteamCheckForWorkshop.h"
 #include "SteamCommands.h"
+#include "DarkLUA.h"
 
 // Internal Includes
 #include "DBDLLCore.h"
@@ -1206,6 +1207,9 @@ DARKSDK void EncryptAllFiles(char* dwStringAddress)
 	// add first directory into the listing
 	directoryListStack.push ( folderToCheck );
 
+	// Added Code to pre-compile Lua scripts
+	LoadLua("ggprecompile.lua");
+
 	// keep going until we have emptied the directory stack
 	while ( !directoryListStack.empty ( ) )
 	{
@@ -1244,7 +1248,14 @@ DARKSDK void EncryptAllFiles(char* dwStringAddress)
 				}
 				else
 				{
-					if ( strstr(data.cFileName, ".fpe") != NULL || strstr(data.cFileName, ".dds") != NULL ||  strstr(data.cFileName, ".png") != NULL ||  strstr(data.cFileName, ".jpg") != NULL || strstr(data.cFileName, ".x") != NULL || strstr(data.cFileName, ".dbo") != NULL ||  strstr(data.cFileName, ".wav") != NULL ||  strstr(data.cFileName, ".mp3") != NULL )
+					if ( strstr(data.cFileName, ".fpe") != NULL || 
+						 strstr(data.cFileName, ".dds") != NULL ||  
+						 strstr(data.cFileName, ".png") != NULL || 
+						 strstr(data.cFileName, ".jpg") != NULL ||
+						 strstr(data.cFileName, ".x")   != NULL ||
+						 strstr(data.cFileName, ".dbo") != NULL ||
+						 strstr(data.cFileName, ".wav") != NULL ||
+						 strstr(data.cFileName, ".mp3") != NULL )
 					{
 						// dont encrypt a file if it already is
 						if ( strstr ( data.cFileName, "_e_" )  !=  data.cFileName )
@@ -1264,6 +1275,22 @@ DARKSDK void EncryptAllFiles(char* dwStringAddress)
 							UpdateWindow ( NULL );
 							sprintf ( p, "%s\\%s", szCurrentDirectory , f );
 							if ( bEncryptedOkay==true ) DeleteFile ( p );
+						}
+					}
+					else 
+					{
+						if ( strstr(data.cFileName, ".lua") != NULL &&
+							 strstr(data.cFileName, "multiplayer") == NULL )
+						{
+							// Precompile lua script, note: overwrites file, in theory if the call
+							// fails for any reason the file should remain uncompiled.
+							char p[MAX_PATH];
+
+							sprintf(p, "%s\\%s", szCurrentDirectory, data.cFileName);
+
+							LuaSetFunction("ggprecompile", 1, 0);
+							LuaPushString(p);
+							LuaCall();
 						}
 					}
 				}

--- a/GameGuru/ggprecompile.lua
+++ b/GameGuru/ggprecompile.lua
@@ -1,0 +1,9 @@
+function ggprecompile(infile)
+	if infile == nil then return end
+	local p = loadfile(infile)
+	local outfile = infile
+	local f = io.open(outfile, "wb")
+	f:write(string.dump(p))
+	f:close()
+end
+


### PR DESCRIPTION
…ayer" in the name).  Uses the ggprecompile.lua script to do the actual precompile part and overwrites the .lua script so that runtime loading code does not need to be changed.