### PR TITLE
PE BUG FIX: GG sometimes hang.

### DIFF
--- a/GameGuru Core/GameGuru/Include/Types.h
+++ b/GameGuru Core/GameGuru/Include/Types.h
@@ -5244,6 +5244,7 @@ struct entityprofiletype
 		 quantity = 0;
 		 footfallmax = 0;
 		 startofaianim = 0;
+		 appendanimmax = 0;
 		 animmax = 0;
 		 firespotlimb = 0;
 		 spine2 = 0;

--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -1011,6 +1011,7 @@ void entity_loaddata ( void )
 		//  Must be reset before parse
 		t.entityprofile[t.entid].limbmax=0;
 		t.entityprofile[t.entid].animmax=0;
+		t.entityprofile[t.entid].appendanimmax=0; //PE: sometimes , caused endless loop, was never set anywhere.
 		t.entityprofile[t.entid].footfallmax=0;
 		t.entityprofile[t.entid].headlimb=-1;
 		t.entityprofile[t.entid].firespotlimb=-1;
@@ -1679,7 +1680,10 @@ void entity_loaddata ( void )
 						if ( t.entityprofile[t.entid].appendanimmax > 99 ) 
 							t.entityprofile[t.entid].appendanimmax = 99;
 					}
-					if ( t.entityprofile[t.entid].appendanimmax > 0 ) 
+
+					//PE: Hanging, in my case: appendanimmax=573444874 value_s=road_straight01.x
+					//PE: Hang if you are unlucky and get mem that "appendanimmax" are not already set to zero.
+					if ( t.entityprofile[t.entid].appendanimmax > 0 && t.entityprofile[t.entid].appendanimmax <= 99 )
 					{
 						for ( int aa = 1 ; aa <= t.entityprofile[t.entid].appendanimmax; aa++ )
 						{


### PR DESCRIPTION
appendanimmax dont have a default in : entityprofiletype
In my case where it was hanging: appendanimmax=573444874 value_s=road_straight01.x
Happen if you are unlucky and get mem area where "appendanimmax" are not already set to zero in.

entity_loaddata() -> for ( int aa = 1 ; aa <= t.entityprofile[t.entid].appendanimmax; aa++ )