### PR TITLE
PE: Fix - physics system is fixed at 60 FPS

### DIFF
--- a/GameGuru Core/GameGuru/Source/M-Physics.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Physics.cpp
@@ -884,7 +884,6 @@ void physics_loop ( void )
 		//  only process physics once we reach the minimum substep constant
 		if ( t.tphysicsadvance_f>0.05f ) t.tphysicsadvance_f = 0.05f;
 		t.machineindependentphysicsupdate = timeGetSecond();
-		ODEUpdate ( );//t.tphysicsadvance_f );
 		ODEUpdate ( t.tphysicsadvance_f );
 	}
 }

--- a/GameGuru Core/GameGuru/Source/M-Physics.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Physics.cpp
@@ -885,6 +885,7 @@ void physics_loop ( void )
 		if ( t.tphysicsadvance_f>0.05f ) t.tphysicsadvance_f = 0.05f;
 		t.machineindependentphysicsupdate = timeGetSecond();
 		ODEUpdate ( );//t.tphysicsadvance_f );
+		ODEUpdate ( t.tphysicsadvance_f );
 	}
 }
 


### PR DESCRIPTION
PE: Fix - physics system is fixed at 60 FPS, if you have a lower or higher FPS the physics system do not work, and produce wrong player movement and physics behavior.
