### PR TITLE
PE: 11-06-2019

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/BlitzTerrain/main.h
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/BlitzTerrain/main.h
@@ -20,7 +20,7 @@
 #define C_BT_FULLVERSION
 #define C_BT_VERSION 200
 #define C_BT_MAXTERRAINS 255
-#define C_BT_MAXLODLEVELS 255
+#define C_BT_MAXLODLEVELS 16 //PE: org 255 , just waste mem and cpu.
 #define C_BT_MAXTERRAINSIZE 4096
 #define BT_VERSION "2.02 R2 FULL"
 

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
@@ -2364,6 +2364,15 @@ int SetSpriteSize ( lua_State *L )
 	}
 	else
 	{
+		//PE: 11-06-19 issue: https://github.com/TheGameCreators/GameGuruRepo/issues/504
+		//PE: I cant test this on my system , but assume we could always use the backbuffer size g_pGlob->iScreenWidth instead of the screenwidth g_dwScreenWidth
+		//PE: Can someone with a similar screen setup do this, test the return of these 2 MessageBox.
+		//PE: They should always be the same , but issue indicate they are not.
+		//PE: Just add rader.lua and enable the below 4 lines to test :)
+//		char tmp[80]; sprintf(tmp, "g_pGlob->iScreenWidth: %d", g_pGlob->iScreenWidth); // 1920
+//		MessageBox(NULL, tmp, "g_pGlob->iScreenWidth", MB_TOPMOST | MB_OK);
+//		sprintf(tmp, "g_dwScreenWidth: %d", g_dwScreenWidth); // 1920
+//		MessageBox(NULL, tmp, "g_dwScreenWidth", MB_TOPMOST | MB_OK);
 		float perc = ( sizeX / ImageWidth(GetSpriteImage(iID)) ) * 100.0f;
 		sizeY = (( perc * ImageHeight(GetSpriteImage(iID)) ) / 100.0f) * ( g_dwScreenWidth / g_dwScreenHeight );
 	}

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/BoxCollision/CCollision.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/BoxCollision/CCollision.cpp
@@ -1498,6 +1498,22 @@ float CheckIntersectObject ( sObject* pObject, float fX, float fY, float fZ, flo
 		GetRayCollision ( pObject, fX, fY, fZ, fNewX, fNewY, fNewZ, &fDistance );
 	else
 		GetRayCollisionBoxFirst ( pObject, fX, fY, fZ, fNewX, fNewY, fNewZ, &fDistance );
+	
+	//PE: 11-06-19 issue: https://github.com/TheGameCreators/GameGuruRepo/issues/502
+	//PE: Some animations have bone collision problems so test mesh if this is the case.
+	//PE: This is a editor only function so will not have any speed impact in game.
+	if (fDistance == 0.0f && !pObject->bIgnoreDefAnim && RayCollisionDoBoxCheckFirst == false ) {
+		sObject* pActualObject = pObject;
+		if (pActualObject->pInstanceOfObject)
+			pActualObject = pActualObject->pInstanceOfObject;
+		if (pActualObject->pAnimationSet) {
+			//PE: iUseNewTransformedVertsMode fails for some animated object
+			//PE: So in this case also test using mesh and ignore bones.
+			pObject->bIgnoreDefAnim = true;
+			GetRayCollision(pObject, fX, fY, fZ, fNewX, fNewY, fNewZ, &fDistance);
+			pObject->bIgnoreDefAnim = false;
+		}
+	}
 
 	// return result
 	return fDistance;

--- a/GameGuru Core/GameGuru/Include/gameguru.h
+++ b/GameGuru Core/GameGuru/Include/gameguru.h
@@ -514,7 +514,11 @@ struct Sglobals
 	int showstaticlightinrealtime;
 
 	int videoprecacheframes;
+	int aidisabletreeobstacles;
+	int aidisableobstacles;
+	int skipunusedtextures;
 	int videodelayedload;
+
 	int grawtextsizelast;
 	int grenadeexplosion;
 	DWORD guniquesignature;

--- a/GameGuru Core/GameGuru/Include/gameguru.h
+++ b/GameGuru Core/GameGuru/Include/gameguru.h
@@ -513,6 +513,8 @@ struct Sglobals
 	int terrainlightfadedistance;
 	int showstaticlightinrealtime;
 
+	int videoprecacheframes;
+	int videodelayedload;
 	int grawtextsizelast;
 	int grenadeexplosion;
 	DWORD guniquesignature;

--- a/GameGuru Core/GameGuru/Source/Common-Images.cpp
+++ b/GameGuru Core/GameGuru/Source/Common-Images.cpp
@@ -102,7 +102,7 @@ void loadinternalimageexcompressquality ( char* tfile_s, int imgid, int compress
 		if ( ttry == 1  ) { tryfile_s = Left(tfile_s,Len(tfile_s)-4); tryfile_s += ".dds"; }
 		if ( ttry == 2  ) { tryfile_s = tfile_s; }
 		if ( ttry == 3  ) { tryfile_s = Left(tfile_s,Len(tfile_s)-4); tryfile_s += ".png"; }
-		if ( ttry == 4  ) { tryfile_s = Left(tfile_s,Len(tfile_s)-3); tryfile_s += g.imgext_s.Get(); }
+		if ( ttry == 4  ) { tryfile_s = Left(tfile_s,Len(tfile_s)-3); tryfile_s += g.imgext_s.Get(); } //PE: tga
 		if ( GetImageFileExist(tryfile_s.Get()) == 1 ) 
 		{
 			if ( g.gincludeonlyvideo == 1 && cstr(Left(Lower(tryfile_s.Get()),Len(g.gincludeonlyname_s.Get()))) != cstr(Lower(g.gincludeonlyname_s.Get())) ) 
@@ -403,7 +403,8 @@ int loadinternaltextureex ( char* tfile_s, int compressmode, int quality )
 	{
 		for ( tt = 1 ; tt <=  g.texturebankmax; tt++ )
 		{
-			if ( strcmp ( tfile_s , t.texturebank_s[tt].Get() ) == 0 ) { texid = g.texturebankoffset+tt  ; break; }
+			//PE: Sometimes we get double load , due to upper/lower case so stricmp.
+			if ( stricmp ( tfile_s , t.texturebank_s[tt].Get() ) == 0 ) { texid = g.texturebankoffset+tt  ; break; }
 		}
 	}
 	else

--- a/GameGuru Core/GameGuru/Source/Common.cpp
+++ b/GameGuru Core/GameGuru/Source/Common.cpp
@@ -1689,6 +1689,10 @@ void FPSC_SetDefaults ( void )
 	g.standalonefreememorybetweenlevels = 0;
 	g.videoprecacheframes = 2;
 	g.videodelayedload = 1;
+	g.aidisabletreeobstacles = 0;
+	g.aidisableobstacles = 0;
+	g.skipunusedtextures = 0;
+
 	g.lowestnearcamera = 2; //PE: default , use setup.ini lowestnearcamera to adjust.
 	g.memgeneratedump = 0;
 	g.underwatermode = 0;
@@ -1952,6 +1956,11 @@ void FPSC_LoadSETUPINI ( void )
 					t.tryfield_s = "standalonefreememorybetweenlevels"; if (t.field_s == t.tryfield_s)  g.standalonefreememorybetweenlevels = t.value1;
 					t.tryfield_s = "videoprecacheframes"; if (t.field_s == t.tryfield_s)  g.videoprecacheframes = t.value1;
 					t.tryfield_s = "videodelayedload"; if (t.field_s == t.tryfield_s)  g.videodelayedload = t.value1;
+					
+					t.tryfield_s = "aidisabletreeobstacles"; if (t.field_s == t.tryfield_s)  g.aidisabletreeobstacles = t.value1;
+					t.tryfield_s = "aidisableobstacles"; if (t.field_s == t.tryfield_s)  g.aidisableobstacles = t.value1;
+					t.tryfield_s = "skipunusedtextures"; if (t.field_s == t.tryfield_s)  g.skipunusedtextures = t.value1;
+					
 					t.tryfield_s = "lowestnearcamera"; if (t.field_s == t.tryfield_s)  g.lowestnearcamera = t.value1;
 					t.tryfield_s = "editorsavebak"; if (t.field_s == t.tryfield_s)  g.editorsavebak = t.value1;
 

--- a/GameGuru Core/GameGuru/Source/Common.cpp
+++ b/GameGuru Core/GameGuru/Source/Common.cpp
@@ -1687,6 +1687,8 @@ void FPSC_SetDefaults ( void )
 	g.showstaticlightinrealtime = 0;
 
 	g.standalonefreememorybetweenlevels = 0;
+	g.videoprecacheframes = 2;
+	g.videodelayedload = 1;
 	g.lowestnearcamera = 2; //PE: default , use setup.ini lowestnearcamera to adjust.
 	g.memgeneratedump = 0;
 	g.underwatermode = 0;
@@ -1948,6 +1950,8 @@ void FPSC_LoadSETUPINI ( void )
 					t.tryfield_s = "underwatermode"; if (t.field_s == t.tryfield_s)  g.underwatermode = t.value1;
 					t.tryfield_s = "memskipwatermask"; if (t.field_s == t.tryfield_s)  g.memskipwatermask = t.value1;
 					t.tryfield_s = "standalonefreememorybetweenlevels"; if (t.field_s == t.tryfield_s)  g.standalonefreememorybetweenlevels = t.value1;
+					t.tryfield_s = "videoprecacheframes"; if (t.field_s == t.tryfield_s)  g.videoprecacheframes = t.value1;
+					t.tryfield_s = "videodelayedload"; if (t.field_s == t.tryfield_s)  g.videodelayedload = t.value1;
 					t.tryfield_s = "lowestnearcamera"; if (t.field_s == t.tryfield_s)  g.lowestnearcamera = t.value1;
 					t.tryfield_s = "editorsavebak"; if (t.field_s == t.tryfield_s)  g.editorsavebak = t.value1;
 

--- a/GameGuru Core/GameGuru/Source/G-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/G-Entity.cpp
@@ -21,6 +21,7 @@ void entity_init ( void )
 	//  activate all entities and perform any pre-test game setup
 	timestampactivity(0,"Configure entity attachments and AI obstacles");
 	g.entityattachmentindex=0;
+	//PE: This takes 30 sec. and take 400 MB. mem in FatherIsland, perhaps another faster way could be made.
 	for ( t.e = 1 ; t.e<=  g.entityelementlist; t.e++ )
 	{
 		t.entid=t.entityelement[t.e].bankindex;
@@ -55,7 +56,8 @@ void entity_init ( void )
 							{
 								t.ttreemode=t.entityprofile[t.entid].collisionmode-50;
 								//  dont need to setup ai for multiplayer since it doesnt use any ai - unless coop mode!
-								if (  t.game.runasmultiplayer == 0 || ( g.steamworks.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 ) ) 
+								//aidisabletreeobstacles
+								if ( g.aidisabletreeobstacles == 0 && ( t.game.runasmultiplayer == 0 || ( g.steamworks.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 )) )
 								{
 									darkai_setup_tree ( );
 								}
@@ -65,7 +67,10 @@ void entity_init ( void )
 								//  dont need to setup ai for multiplayer since it doesnt use any ai
 								if (  t.game.runasmultiplayer == 0 || ( g.steamworks.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 ) ) 
 								{
-									 if ( t.entityprofile[t.entid].collisionmode != 11 && t.entityprofile[t.entid].collisionmode != 12 ) darkai_setup_entity ( );
+									//aidisableobstacles
+									if( g.aidisableobstacles == 0 && t.entityprofile[t.entid].collisionmode != 11 && t.entityprofile[t.entid].collisionmode != 12 ) {
+										darkai_setup_entity();
+									}
 								}
 							}
 						}

--- a/GameGuru Core/GameGuru/Source/G-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/G-Entity.cpp
@@ -56,8 +56,7 @@ void entity_init ( void )
 							{
 								t.ttreemode=t.entityprofile[t.entid].collisionmode-50;
 								//  dont need to setup ai for multiplayer since it doesnt use any ai - unless coop mode!
-								//aidisabletreeobstacles
-								if ( g.aidisabletreeobstacles == 0 && ( t.game.runasmultiplayer == 0 || ( g.steamworks.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 )) )
+								if ( g.aidisabletreeobstacles == 0 && (t.game.runasmultiplayer == 0 || ( g.mp.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 ) ) ) 
 								{
 									darkai_setup_tree ( );
 								}
@@ -65,12 +64,9 @@ void entity_init ( void )
 							else
 							{
 								//  dont need to setup ai for multiplayer since it doesnt use any ai
-								if (  t.game.runasmultiplayer == 0 || ( g.steamworks.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 ) ) 
+								if (  t.game.runasmultiplayer == 0 || ( g.mp.coop  ==  1 && t.entityprofile[t.entid].ismultiplayercharacter  ==  0 ) ) 
 								{
-									//aidisableobstacles
-									if( g.aidisableobstacles == 0 && t.entityprofile[t.entid].collisionmode != 11 && t.entityprofile[t.entid].collisionmode != 12 ) {
-										darkai_setup_entity();
-									}
+									 if ( g.aidisableobstacles == 0 && t.entityprofile[t.entid].collisionmode != 11 && t.entityprofile[t.entid].collisionmode != 12 ) darkai_setup_entity ( );
 								}
 							}
 						}

--- a/GameGuru Core/GameGuru/Source/M-Debug.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Debug.cpp
@@ -71,6 +71,14 @@ void backuptimestampactivity(void)
 	}
 }
 
+#define USEAPPENDLOG
+#ifdef USEAPPENDLOG
+	//PE: Way faster , in a large standalone debug can take upto 2 minutes longer to load the old way.
+	#include "stdio.h"
+	int debugfilenetries = 0;
+
+#endif
+
 void timestampactivity ( int i, char* desc_s )
 {
 	cstr videomemsofardesc_s =  "";
@@ -82,6 +90,49 @@ void timestampactivity ( int i, char* desc_s )
 	cstr file_s =  "";
 	int smem = 0;
 	int mem = 0;
+
+#ifdef USEAPPENDLOG
+	if (g.gproducelogfiles == 1)
+	{
+		file_s = g.fpscrootdir_s + "\\" + g.trueappname_s + ".log";
+
+		if (debugfilenetries == 0) {
+			if (FileExist(file_s.Get()) == 1)  DeleteAFile(file_s.Get());
+		}
+
+		smem = SMEMAvailable(1);
+		memdesc_s = Str((smem - g.timestampactivitymemthen) / 1024);
+		memdesc_s = memdesc_s + "MB";
+		g.timestampactivitymemthen = smem;
+		if (g.gproducetruevidmemreading == 1)
+		{
+			Sync();
+		}
+		mem = DMEMAvailable();
+		videomemdesc_s = Str((mem - g.timestampactivityvideomemthen)); videomemdesc_s = videomemdesc_s + "MB";
+		g.timestampactivityvideomemthen = mem;
+		videomemsofardesc_s = " ("; videomemsofardesc_s = videomemsofardesc_s + Str(smem / 1024) + "," + Str(DMEMAvailable()) + ")";
+		tpart1_s = Str(Timer()); tpart1_s = tpart1_s + " : " + desc_s + " ";
+		tpart2_s = "S:"; tpart2_s = tpart2_s + memdesc_s;
+		tpart3_s = "V:"; tpart3_s = tpart3_s + videomemsofardesc_s;
+		if (Len(tpart1_s.Get())<64)  tpart1_s = tpart1_s + Spaces(64 - Len(tpart1_s.Get()));
+		if (Len(tpart2_s.Get())<8)  tpart2_s = tpart2_s + Spaces(8 - Len(tpart2_s.Get()));
+		if (Len(tpart3_s.Get())<16)  tpart3_s = tpart3_s + Spaces(16 - Len(tpart3_s.Get()));
+		t.timestampactivity_s[0] = tpart1_s;
+		t.timestampactivity_s[0] += tpart2_s;
+		t.timestampactivity_s[0] += tpart3_s;
+
+		FILE * pFile;
+		pFile = fopen(file_s.Get(), "a+");
+		if (pFile != NULL)
+		{
+			fputs( t.timestampactivity_s[0].Get(), pFile);
+			fputs("\n", pFile);
+			fclose(pFile);
+		}
+		debugfilenetries++;
+	}
+#else
 	if ( g.gproducelogfiles == 1 ) 
 	{
 		if ( i == 0 ) 
@@ -137,5 +188,44 @@ void timestampactivity ( int i, char* desc_s )
 			CloseFile (  13 );
 		}
 	}
+#endif
 }
+
+void timestampactivityConsole(int i, char* desc_s)
+{
+	cstr videomemsofardesc_s = "";
+	cstr videomemdesc_s = "";
+	cstr memdesc_s = "";
+	cstr tpart1_s = "";
+	cstr tpart2_s = "";
+	cstr tpart3_s = "";
+	cstr file_s = "";
+	int smem = 0;
+	int mem = 0;
+
+	smem = SMEMAvailable(1);
+	memdesc_s = Str((smem - g.timestampactivitymemthen) / 1024);
+	memdesc_s = memdesc_s + "MB";
+	g.timestampactivitymemthen = smem;
+	if (g.gproducetruevidmemreading == 1)
+	{
+		Sync();
+	}
+	mem = DMEMAvailable();
+	videomemdesc_s = Str((mem - g.timestampactivityvideomemthen)); videomemdesc_s = videomemdesc_s + "MB";
+	g.timestampactivityvideomemthen = mem;
+	videomemsofardesc_s = " ("; videomemsofardesc_s = videomemsofardesc_s + Str(smem / 1024) + "," + Str(DMEMAvailable()) + ")";
+	tpart1_s = Str(Timer()); tpart1_s = tpart1_s + " : " + desc_s + " ";
+	tpart2_s = "S:"; tpart2_s = tpart2_s + memdesc_s;
+	tpart3_s = "V:"; tpart3_s = tpart3_s + videomemsofardesc_s;
+	if (Len(tpart1_s.Get())<64)  tpart1_s = tpart1_s + Spaces(64 - Len(tpart1_s.Get()));
+	if (Len(tpart2_s.Get())<8)  tpart2_s = tpart2_s + Spaces(8 - Len(tpart2_s.Get()));
+	if (Len(tpart3_s.Get())<16)  tpart3_s = tpart3_s + Spaces(16 - Len(tpart3_s.Get()));
+	t.timestampactivity_s[0] = tpart1_s;
+	t.timestampactivity_s[0] += tpart2_s;
+	t.timestampactivity_s[0] += tpart3_s;
+	OutputDebugString(t.timestampactivity_s[0].Get());
+	OutputDebugString("\n");
+}
+
 

--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -2319,7 +2319,7 @@ void entity_loadvideoid ( void )
 		{
 			if (  AnimationExist(t.tt) == 0 ) { t.tvideoid = t.tt  ; break; }
 		}
-		LoadAnimation ( t.tvideofile_s.Get(), t.tvideoid );
+		LoadAnimation ( t.tvideofile_s.Get(), t.tvideoid , g.videoprecacheframes , g.videodelayedload );
 	}
 }
 

--- a/GameGuru Core/GameGuru/Source/M-Entity.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Entity.cpp
@@ -2966,8 +2966,8 @@ void entity_loadtexturesandeffect ( void )
 
 					// height texture
 					cstr pHeighttex_s = t.texdirnoext_s+"_height.dds";
-					t.texuseid = loadinternaltextureex(pHeighttex_s.Get(),1,t.tfullorhalfdivide);
-					if ( t.texuseid == 0 ) 
+					if( g.skipunusedtextures == 0 ) t.texuseid = loadinternaltextureex(pHeighttex_s.Get(),1,t.tfullorhalfdivide);
+					if ( t.texuseid == 0 || g.skipunusedtextures == 1 )
 					{
 						t.texuseid = loadinternaltextureex("effectbank\\reloaded\\media\\blank_black.dds",1,t.tfullorhalfdivide);
 					}
@@ -3000,8 +3000,8 @@ void entity_loadtexturesandeffect ( void )
 							{
 								// Detail texture
 								cstr pDetailtex_s = t.texdirnoext_s + "_detail.dds";
-								t.entityprofile[t.entid].texlid = loadinternaltextureex(pDetailtex_s.Get(), 1, t.tfullorhalfdivide);
-								if (t.entityprofile[t.entid].texlid == 0)
+								if( g.skipunusedtextures == 0 ) t.entityprofile[t.entid].texlid = loadinternaltextureex(pDetailtex_s.Get(), 1, t.tfullorhalfdivide);
+								if (t.entityprofile[t.entid].texlid == 0 || g.skipunusedtextures == 1)
 								{
 									t.entityprofile[t.entid].texlid = loadinternaltextureex("effectbank\\reloaded\\media\\detail_default.dds", 1, t.tfullorhalfdivide);
 								}

--- a/GameGuru Core/GameGuru/Source/M-MapFile.cpp
+++ b/GameGuru Core/GameGuru/Source/M-MapFile.cpp
@@ -1406,8 +1406,10 @@ void mapfile_savestandalone ( void )
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "memskipwatermask=" + Str(g.memskipwatermask); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "lowestnearcamera=" + Str(g.lowestnearcamera); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "standalonefreememorybetweenlevels=" + Str(g.standalonefreememorybetweenlevels); ++t.i;
-
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "videoprecacheframes=" + Str(g.videoprecacheframes); ++t.i;
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "aidisabletreeobstacles=" + Str(g.aidisabletreeobstacles); ++t.i;
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "aidisableobstacles=" + Str(g.aidisableobstacles); ++t.i;
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "skipunusedtextures=" + Str(g.skipunusedtextures); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "videodelayedload=" + Str(g.videodelayedload); ++t.i;
 
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "maxtotalmeshlights=" + Str(g.maxtotalmeshlights); ++t.i;

--- a/GameGuru Core/GameGuru/Source/M-MapFile.cpp
+++ b/GameGuru Core/GameGuru/Source/M-MapFile.cpp
@@ -29,6 +29,7 @@ void mapfile_saveproject_fpm ( void )
 		backupname[strlen(backupname) - 1] = 'k';
 		backupname[strlen(backupname) - 2] = 'a';
 		backupname[strlen(backupname) - 3] = 'b';
+		DeleteAFile(backupname);
 		CopyAFile(t.ttempprojfilename_s.Get(), backupname);
 	}
 
@@ -1406,6 +1407,8 @@ void mapfile_savestandalone ( void )
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "lowestnearcamera=" + Str(g.lowestnearcamera); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "standalonefreememorybetweenlevels=" + Str(g.standalonefreememorybetweenlevels); ++t.i;
 
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "videoprecacheframes=" + Str(g.videoprecacheframes); ++t.i;
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "videodelayedload=" + Str(g.videodelayedload); ++t.i;
 
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "maxtotalmeshlights=" + Str(g.maxtotalmeshlights); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "maxpixelmeshlights=" + Str(g.maxpixelmeshlights); ++t.i;

--- a/GameGuru Core/Include/CAnimation.h
+++ b/GameGuru Core/Include/CAnimation.h
@@ -55,7 +55,7 @@ DARKSDK void PreventTextureLock				( bool bDoNotLock );
 DARKSDK void UpdateAllAnimation				( void );
 DARKSDK BOOL DB_FreeAnimation				( int AnimIndex );
 
-DARKSDK void LoadAnimation					( LPSTR pFilename, int iIndex );
+DARKSDK void LoadAnimation					( LPSTR pFilename, int iIndex, int precacheframes, int videodelayedload );
 DARKSDK int GetAnimationLength				( int animindex );
 DARKSDK void PlayAnimation					( int iIndex );
 DARKSDK void DeleteAnimation				( int animindex );

--- a/GameGuru IDE/MainFrm.cpp
+++ b/GameGuru IDE/MainFrm.cpp
@@ -1754,7 +1754,13 @@ void CMainFrame::OnTestGame()
 
 void CMainFrame::OnMultiplayerGame() 
 {
-	TestOrMultiplayerGame(1);
+	//PE: 12-05-19 issue: https://github.com/TheGameCreators/GameGuruRepo/issues/505
+	UINT flags = MB_TASKMODAL;
+	flags |= MB_ICONQUESTION;
+	flags |= MB_OKCANCEL;
+	if (MessageBoxA("Launch multiplayer mode ?\n\nNOTE: Make sure you have saved any changes to the map your currently editing.", "Are you sure ?", flags) == IDOK ) {
+		TestOrMultiplayerGame(1);
+	}
 }
 
 void CMainFrame::OnUpdateTestGame ( CCmdUI* pCmdUI )

--- a/GameGuru/Files/effectbank/reloaded/apbr_basic.fx
+++ b/GameGuru/Files/effectbank/reloaded/apbr_basic.fx
@@ -1,3 +1,4 @@
 string Description = "PBR Shader";
 #define ALPHACLIP 0.1
+#define SHADOWALPHACLIP 0.70
 #include "apbr_core.fx"

--- a/GameGuru/Files/effectbank/reloaded/apbr_core.fx
+++ b/GameGuru/Files/effectbank/reloaded/apbr_core.fx
@@ -1703,11 +1703,20 @@ float4 depthPS(in VSOutput input) : SV_TARGET
 #ifdef ALPHADISABLED
     rawdiffusemap.a = 1;
 #else
-	if( rawdiffusemap.a < ALPHACLIP ) 
-	{
-		clip(-1);
-		return rawdiffusemap;
-	}
+
+#ifdef SHADOWALPHACLIP
+   if( rawdiffusemap.a < SHADOWALPHACLIP ) 
+   {
+      clip(-1);
+      return rawdiffusemap;
+   }
+#else
+   if( rawdiffusemap.a < ALPHACLIP ) 
+   {
+      clip(-1);
+      return rawdiffusemap;
+   }
+#endif
 #endif
    return rawdiffusemap;
 }

--- a/GameGuru/Files/effectbank/reloaded/apbr_illum.fx
+++ b/GameGuru/Files/effectbank/reloaded/apbr_illum.fx
@@ -1,4 +1,5 @@
 string Description = "PBR Shader (Illumination)";
 #define ALPHACLIP 0.1
 #define ILLUMINATIONMAP
+#define SHADOWALPHACLIP 0.70
 #include "apbr_core.fx"

--- a/GameGuru/setup.ini
+++ b/GameGuru/setup.ini
@@ -56,6 +56,9 @@ pbroverride=1
 disableweaponjams=0
 reloadweapongunspecs=0
 videoprecacheframes=1
+aidisabletreeobstacles=0
+aidisableobstacles=0
+skipunusedtextures=0
 videodelayedload=1
 
 [SHADOWS]

--- a/GameGuru/setup.ini
+++ b/GameGuru/setup.ini
@@ -55,6 +55,8 @@ forceloadtestgameshaders=0
 pbroverride=1
 disableweaponjams=0
 reloadweapongunspecs=0
+videoprecacheframes=1
+videodelayedload=1
 
 [SHADOWS]
 editorusemediumshadows=1


### PR DESCRIPTION
Im on a old branch , and need a merge so i can get all the latest installed locally :)
This include some OLD and new fixes:

PE: setup.ini - This will enable delayed Video loading, and will not use any memory before a video is actually playing, and when video is done all memory is released.
So if you use Video in your level this will save you around 90mb memory for each video you have on your level. ( no matter if they are used or not ).
videoprecacheframes=1
videodelayedload=1

PE: setup.ini - For games that dont use AI, setting these to 1 will give you faster loading and save you around 300mb on a avg. level.
aidisabletreeobstacles=0
aidisableobstacles=0

Should not be used for now, but will be expanded as we move forward:
skipunusedtextures=0


PE: Shaders - allow artist to make glass not cast shadows, by splitting out normal alphaclip and shadow alphaclip.

PE: Terrain LOD levels never go higher then 16, so set this as highest to save some CPU and mem.


PE: BUGFIX - Some animations have bone collision problems and cant be selected in the editor, so test mesh if this is the case.
issue: https://github.com/TheGameCreators/GameGuruRepo/issues/502

PE: BUGFIX - Sometimes we get double load, due to upper/lower case. improve loading time and mem.

PE: Add: Additional dialog before "Launch multiplayer" to stop accidentally start of multiplayer.
issue: https://github.com/TheGameCreators/GameGuruRepo/issues/505
issue: https://github.com/TheGameCreators/GameGuruRepo/issues/457

PE: Add: Faster log files , on large levels (standalone) the old system could take up to 2 minute (additional) starting a level. to be used for faster debugging when using producelogfiles=1.
Plus additional function to only sent messages to your debugger.

PE: Help needed to solve issue: https://github.com/TheGameCreators/GameGuruRepo/issues/504



