### PR TITLE
PE-JUNE-7 update.

### DIFF
--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/DarkLUA/DarkLUA.cpp
@@ -3649,7 +3649,7 @@ int SetShaderVariable ( lua_State *L )
 			}
 		}
 	}
-	return 1;
+	return 0;
 }
 
 //Control Water Shader

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/SimonReloaded/SimonReloaded.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/DarkSDKMore/SimonReloaded/SimonReloaded.cpp
@@ -19,6 +19,7 @@ int iLeftVert,iRightVert,iFrontVert,iBackVert,iTopVert,iBottomVert;
 bool **bGridExist;
 int iGrassMemblockThreshhold;
 float fWorldSize;
+bool bDisplayBelowWater;
 
 void InfiniteVegetationConstructor ( void )
 {
@@ -280,7 +281,11 @@ void SetResourceValues(int iGrassObjIN, int iGridObjectStartIN, int iGrassImgIN,
 			CloneObject ( iVegObj, iGridObjectStart );
 		}
 		SetObjectMask(iVegObj,iCameraMask);
-		SetObjectTransparency(iVegObj,6);
+		if( bDisplayBelowWater )
+			SetObjectTransparency(iVegObj,8);
+		else
+			SetObjectTransparency(iVegObj, 6);
+
 		SetObjectCull ( iVegObj, 0 );
 	}
 }
@@ -386,10 +391,13 @@ void SetResourceValues(int iGrassObjIN, int iGridObjectStartIN, int iGrassImgIN,
 	}
 }
 
- void MakeVegetationGrid(int iVegPerMeshIN,  float fVegWidthIN, float fVegHeightIN, int iVegAreaWidthIN, int iGridSizeIN, int iTerrainID, int iOptionalSkipGrassMemblock)
+ void MakeVegetationGrid(int iVegPerMeshIN,  float fVegWidthIN, float fVegHeightIN, int iVegAreaWidthIN, int iGridSizeIN, int iTerrainID, int iOptionalSkipGrassMemblock, bool bBelowWater)
 {
 	if (!bResourcesSet) return;
 	if (GetMeshExist(iGrassObj) == 0) return; // Safety check
+
+
+	bDisplayBelowWater = bBelowWater;
 
 	// Set our 'old' positions miles away so we force a position update on the first VEG UPDATE call
 	fOldViewPointX = -10000;

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Bullet/BulletPhysics.CPP
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Bullet/BulletPhysics.CPP
@@ -3277,13 +3277,16 @@ void ODERemoveBodyCollisionCheck(int iObjectNumber)
 	RemoveObjectCollisionCheck(iObjectNumber);
 }
 
-void ODESetWorldGravity ( float fX, float fY, float fZ )
+void ODESetWorldGravity ( float fX, float fY, float fZ, float fallspeed)
 {
 	// set player gravity (assuming 20 is default)
 	if ( m_character )
 	{
 		float fRelative = fabs(fY/20.0f);
 		m_character->setGravity((fCharacterGravity*fRelative)/gSc);
+		if(fallspeed != 0)
+			m_character->setFallSpeed((fallspeed*fRelative) / gSc);
+		else
 		m_character->setFallSpeed((fCharacterFallSpeed*fRelative)/gSc);
 	}
 }

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/DBOFormat/DBOData.h
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/DBOFormat/DBOData.h
@@ -843,6 +843,7 @@ struct sObjectProperties
 	bool							bGhostedObject;								// flagged if a ghosted object
 	bool							bTransparentObject;							// flagged if a transparent object
 	bool							bTransparencyWaterLine;						// new: transparency water line (for above/below water)
+	bool							bRenderBeforeWater;							// For objects that are both above and below waterline.
 	bool							bNewZLayerObject;							// flagged if requires zbuffer clear
 	bool							bLockedObject;								// flagged if requires a locked camera
 	bool							bStencilObject;								// flagged if object uses the stencil layer

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectManagerC.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectManagerC.cpp
@@ -5361,26 +5361,31 @@ bool CObjectManager::UpdateLayerInner ( int iLayer )
 				// calculate distance from object to camera (fills fCamDistance)
 				if ( pObject->bTransparencyWaterLine==true )
 				{
-					if ( 1 )
-					{
-						// leeadd - 021205 - transparent object water line, using HEIGHY (Y) as ordering (great for water planes)
-						if ( pObject->position.vecPosition.y < fWaterPlaneDivisionY )
-							fWaterPlaneDivisionY = pObject->position.vecPosition.y;
+/*							
+							// leeadd - 021205 - transparent object water line, using HEIGHY (Y) as ordering (great for water planes)
+							if ( pObject->position.vecPosition.y < fWaterPlaneDivisionY )
+								fWaterPlaneDivisionY = pObject->position.vecPosition.y;
 
-						// set as furthest surface distance object (and first to be drawn after underwater objs)
-						// u74b8 - use the current camera
-						if (g_eGlobalSortOrder != E_SORT_BY_DEPTH)
-							pObject->position.fCamDistance = CalculateObjectDistanceFromCamera ( pObject );
-						else
-							pObject->position.fCamDistance = 0.0f;
-						pObject->position.fCamDistance += m_pCamera->fZFar;
-					}
-					else
-					{
-						// PE: After many test this seams to work the best. some transparent object get hidden below water when using above.
-						// LB: 270619 - Not sure which bug this fixed, but it caused water to render above splashes and explosions, and prevented over/under decals from rendering properly
-						//pObject->position.fCamDistance = -1000000.0f; //PE always last
-					}
+							// set as furthest surface distance object (and first to be drawn after underwater objs)
+							// u74b8 - use the current camera
+							if (g_eGlobalSortOrder != E_SORT_BY_DEPTH)
+								pObject->position.fCamDistance = CalculateObjectDistanceFromCamera ( pObject );
+							else
+								pObject->position.fCamDistance = 0.0f;
+
+							pObject->position.fCamDistance += m_pCamera->fZFar;
+*/							
+
+					//PE: Another try :)
+					//PE: Distance to water object (0,600,0) can be huge (we have default camera in center), so below waterline objects dont trigger.
+					//PE: If we just set it to m_pCamera->fZFar , they will trigger as they use (+= m_pCamera->fZFar)
+					//PE: This fix some of the problems and allow pObject->bRenderBeforeWater "SetObjectTransparency(Obj,8)".
+
+					if (pObject->position.vecPosition.y < fWaterPlaneDivisionY)
+						fWaterPlaneDivisionY = pObject->position.vecPosition.y;
+
+					pObject->position.fCamDistance = m_pCamera->fZFar;
+
 					bWaterPlaneDivision = true;
 				}
 				else

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectManagerC.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectManagerC.cpp
@@ -5417,6 +5417,9 @@ bool CObjectManager::UpdateLayerInner ( int iLayer )
 							// u74b8 - use the current camera
 							pObject->position.fCamDistance += m_pCamera->fZFar;
 						}
+						else if( pObject->bRenderBeforeWater ) {
+							pObject->position.fCamDistance += m_pCamera->fZFar;
+						}
 					}
 				}
 

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectsC.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CObjectsC.cpp
@@ -1138,6 +1138,7 @@ DARKSDK_DLL void SetObjectTransparency ( int iID, int iTransparency )
 	// 5 - water line object (seperates depth sort automatically)
 	// 6 - combination of 3 and 4 (second phase render with alpha blend AND alpha test, used for fading LOD leaves)
 	// 7 - very early draw phase no alpha
+	// 8 - below water line , render before water.
 
 	// check the object exists
 	if ( !ConfirmObjectInstance ( iID ) )
@@ -1154,7 +1155,7 @@ DARKSDK_DLL void SetObjectTransparency ( int iID, int iTransparency )
 	{
 		SetTransparency ( pObject->ppMeshList [ iMesh ], bTransparency==TRUE );
 		SetAlphaTest ( pObject->ppMeshList [ iMesh ], 0x0 ); 
-		if ( iTransparency==4 || iTransparency==6 )
+		if ( iTransparency==4 || iTransparency==6 || iTransparency == 8 )
 		{
 			SetAlphaTest ( pObject->ppMeshList [ iMesh ], 0x000000CF );
 		}

--- a/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CommonC.cpp
+++ b/GameGuru Core/Dark Basic Public Shared/Dark Basic Pro SDK/Shared/Objects/CommonC.cpp
@@ -765,7 +765,7 @@ DARKSDK_DLL void UpdateOverlayFlag ( sObject* pObject )
 DARKSDK_DLL void SetObjectTransparency ( sObject* pObject, int iTransparency )
 {
 	// promote to overlay layer (or not)
-	if ( iTransparency==2 || iTransparency==3 || iTransparency==5 || iTransparency==6 )
+	if ( iTransparency==2 || iTransparency==3 || iTransparency==5 || iTransparency==6 || iTransparency == 8 )
 		pObject->bTransparentObject = true;
 	else
 		pObject->bTransparentObject = false;
@@ -775,6 +775,11 @@ DARKSDK_DLL void SetObjectTransparency ( sObject* pObject, int iTransparency )
 		pObject->bTransparencyWaterLine = true;
 	else
 		pObject->bTransparencyWaterLine = false;
+
+	if (iTransparency == 8)
+		pObject->bRenderBeforeWater = true;
+	else
+		pObject->bRenderBeforeWater = false;
 
 	// leeadd - 061208 - transparency mode 7 sets an object to very early draw phase
 	if ( iTransparency==7 )

--- a/GameGuru Core/GameGuru/Include/gameguru.h
+++ b/GameGuru Core/GameGuru/Include/gameguru.h
@@ -515,6 +515,7 @@ struct Sglobals
 	cstr gproducelogfilesdir_s;
 	int gpbroverride;
 	int underwatermode;
+	int usegrassbelowwater;
 	int editorsavebak;
 	int memskipwatermask;
 	int standalonefreememorybetweenlevels;

--- a/GameGuru Core/GameGuru/Source/Common.cpp
+++ b/GameGuru Core/GameGuru/Source/Common.cpp
@@ -1676,6 +1676,7 @@ void FPSC_SetDefaults ( void )
 	g.lowestnearcamera = 2; //PE: default , use setup.ini lowestnearcamera to adjust.
 	g.memgeneratedump = 0;
 	g.underwatermode = 0;
+	g.usegrassbelowwater = 1;
 	g.editorsavebak = 0;
 	g.gproducetruevidmemreading = 0;
 	g.gcharactercapsulescale_f = 1.0;
@@ -1950,6 +1951,8 @@ void FPSC_LoadSETUPINI ( bool bUseMySystemFolder )
 					t.tryfield_s = "producelogfilesdir" ; if (  t.field_s == t.tryfield_s  )  g.gproducelogfilesdir_s = t.value_s;
 					t.tryfield_s = "pbroverride" ; if (  t.field_s == t.tryfield_s  )  g.gpbroverride = t.value1;
 					t.tryfield_s = "underwatermode"; if (t.field_s == t.tryfield_s)  g.underwatermode = t.value1;
+					t.tryfield_s = "usegrassbelowwater"; if (t.field_s == t.tryfield_s)  g.usegrassbelowwater = t.value1;
+
 					t.tryfield_s = "memskipwatermask"; if (t.field_s == t.tryfield_s)  g.memskipwatermask = t.value1;
 					t.tryfield_s = "standalonefreememorybetweenlevels"; if (t.field_s == t.tryfield_s)  g.standalonefreememorybetweenlevels = t.value1;
 					t.tryfield_s = "videoprecacheframes"; if (t.field_s == t.tryfield_s)  g.videoprecacheframes = t.value1;

--- a/GameGuru Core/GameGuru/Source/M-CharacterKit.cpp
+++ b/GameGuru Core/GameGuru/Source/M-CharacterKit.cpp
@@ -1893,7 +1893,11 @@ void characterkit_thumbgadget ( void )
 		if (  t.characterkit.selected  ==  99  )  t.thowmanyrowsmax  =  6;
 		if (  t.characterkit.howManyRows > t.thowmanyrowsmax ) 
 		{
-			t.tsub_f=15.0;
+			//PE: You cant see bottom when using 15 , 16.9 seams to work better.
+			//PE: (this is after installing additional assets )
+			//PE: https://github.com/TheGameCreators/GameGuruRepo/issues/410#issuecomment-506831070
+
+			t.tsub_f = 16.9; //PE: org 15.0;
 			t.tboxleft_f = t.tscrx+64.0+(140.0*4.0);
 			t.tboxright_f = t.tscrx+64.0+(140.0*4.0)+23.0;
 			t.tboxtop_f = t.tscry+ImageHeight(t.timg+1)+3.0 + t.characterkit.scrollPosition;

--- a/GameGuru Core/GameGuru/Source/M-MapFile.cpp
+++ b/GameGuru Core/GameGuru/Source/M-MapFile.cpp
@@ -1532,6 +1532,8 @@ void mapfile_savestandalone_stage4 ( void )
 
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "memskipibr=" + Str(g.memskipibr); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "underwatermode=" + Str(g.underwatermode); ++t.i;
+	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "usegrassbelowwater=" + Str(g.usegrassbelowwater); ++t.i;
+
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "memskipwatermask=" + Str(g.memskipwatermask); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "lowestnearcamera=" + Str(g.lowestnearcamera); ++t.i;
 	t.setuparr_s[t.i] = ""; t.setuparr_s[t.i] = t.setuparr_s[t.i] + "standalonefreememorybetweenlevels=" + Str(g.standalonefreememorybetweenlevels); ++t.i;

--- a/GameGuru Core/GameGuru/Source/M-Terrain.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Terrain.cpp
@@ -187,6 +187,9 @@ void terrain_setupedit ( void )
 		t.effectparam.water.HudFogColor=GetEffectParameterIndex(t.terrain.effectstartindex+1,"HudFogColor");
 	}
 	SetObjectEffect ( t.terrain.objectstartindex+2, t.terrain.effectstartindex+1 );
+
+	SetObjectTransparency(t.terrain.objectstartindex+2, 5); //PE: same mode as test game.
+
 	SetEffectTechnique ( t.terrain.effectstartindex+1, "Editor" );
 
 	// Terrain Edit Settings

--- a/GameGuru Core/GameGuru/Source/M-Terrain.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Terrain.cpp
@@ -4925,7 +4925,10 @@ void terrain_fastveg_init ( void )
 	}
 	int iTrimUsingGrassMemblock = 0;
 	if ( t.game.gameisexe == 1 ) iTrimUsingGrassMemblock = t.terrain.grassmemblock;
-	MakeVegetationGrid ( 4.0f*t.visuals.VegQuantity_f,t.visuals.VegWidth_f,t.visuals.VegHeight_f,terrain_veg_areawidth,t.terrain.vegetationgridsize,t.tTerrainID, iTrimUsingGrassMemblock );
+	if( g.usegrassbelowwater > 0)
+		MakeVegetationGrid(4.0f*t.visuals.VegQuantity_f, t.visuals.VegWidth_f, t.visuals.VegHeight_f, terrain_veg_areawidth, t.terrain.vegetationgridsize, t.tTerrainID, iTrimUsingGrassMemblock , true );
+	else
+		MakeVegetationGrid( 4.0f*t.visuals.VegQuantity_f,t.visuals.VegWidth_f,t.visuals.VegHeight_f,terrain_veg_areawidth,t.terrain.vegetationgridsize,t.tTerrainID, iTrimUsingGrassMemblock , false );
 }
 
 void terrain_fastveg_setgrassimage ( void )

--- a/GameGuru Core/GameGuru/Source/M-Terrain.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Terrain.cpp
@@ -4727,7 +4727,15 @@ void terrain_water_loop ( void )
 			PositionObject (  t.terrain.objectstartindex+4,CameraPositionX(),t.terrain.waterliney_f-t.terrain.WaterCamY_f,CameraPositionZ() );
 			if (  ObjectExist(t.terrain.objectstartindex+8) == 1  )  PositionObject (  t.terrain.objectstartindex+8,CameraPositionX(),t.terrain.waterliney_f-t.terrain.WaterCamY_f,CameraPositionZ() );
 			PositionCamera (  2,CameraPositionX(),t.terrain.waterliney_f-t.terrain.WaterCamY_f,CameraPositionZ() );
-			RotateCamera (  2,-CameraAngleX(),CameraAngleY(),CameraAngleZ() );
+
+			if (g.luacameraoverride == 2 || g.luacameraoverride == 3) {
+				//PE: Why ohh why is Z negative when using g.luacameraoverride=3 || 2 ???????
+				//PE: ? ? ? a matrix problem somewhere ? ? ?
+				RotateCamera(2, -CameraAngleX(0), CameraAngleY(0), -CameraAngleZ(0));
+			}
+			else {
+				RotateCamera(2, -CameraAngleX(0), CameraAngleY(0), CameraAngleZ(0));
+			}
 			//  only render terrain/objects if mode allows
 			if (  t.visuals.reflectionmode>25 ) 
 			{

--- a/GameGuru Core/GameGuru/Source/M-Visuals.cpp
+++ b/GameGuru Core/GameGuru/Source/M-Visuals.cpp
@@ -1844,6 +1844,17 @@ void visuals_underwater_on ( void )
 //		t.visuals.FogB_f = 8;
 //		t.visuals.FogA_f = 255;
 
+		//PE: lower gravity underwater.
+		//PE: for community to approve or remove :)
+		if (t.playercontrol.gravityactive == 1)
+		{
+			//PE: setting the gravity lower make you sink to slow so.
+			ODESetWorldGravity(0, -15.0, 0, 150.0 );
+		}
+		else
+		{
+			ODESetWorldGravity(0, 0, 0);
+		}
 
 		t.tFogR_f = t.visuals.FogR_f; t.tFogG_f = t.visuals.FogG_f; t.tFogB_f = t.visuals.FogB_f ; t.tFogA_f = t.visuals.FogA_f;
 		t.tFogNear_f = t.visuals.FogNearest_f; t.tFogFar_f = t.visuals.FogDistance_f;
@@ -1877,6 +1888,17 @@ void visuals_underwater_off ( void )
 		terrain_setfog ( );
 		terrain_water_setfog ( );
 		t.visuals.underwatermode = 0;
+		//PE: Restore gravity.
+		if (t.playercontrol.gravityactive == 1)
+		{
+			ODESetWorldGravity(0, -20, 0 , 0);
+		}
+		else
+		{
+			ODESetWorldGravity(0, 0, 0);
+		}
+
+
 		//PE: Restore normal fog and disable screen wave effect.
 		visuals_justshaderupdate();
 		if (g.underwatermode == 1) {

--- a/GameGuru Core/Include/BulletPhysics.H
+++ b/GameGuru Core/Include/BulletPhysics.H
@@ -123,7 +123,7 @@ DARKSDK void		ODESetBodyFriction						( int iObject, float fFriction );
 DARKSDK void		ODESetBodyDamping                       ( int iObject, float fDamp, float fAngleDamp );
 
 // world functions
-DARKSDK void		ODESetWorldGravity						( float fX, float fY, float fZ );
+DARKSDK void		ODESetWorldGravity						( float fX, float fY, float fZ , float fallspeed = 0 );
 
 // Get commands
 DARKSDK DWORD		ODEGetBodyLinearVelocityX				( int iObjectNumber );

--- a/GameGuru Core/Include/SimonReloaded.h
+++ b/GameGuru Core/Include/SimonReloaded.h
@@ -16,7 +16,7 @@ void SetTerrainMask(int iMask);
  int ClampToMemblockRes(float fValue);
  bool GridSquareContainsGrass(int iX, int iZ);
  void RefreshGridExistArray(void);
- void MakeVegetationGrid(int iVegPerMeshIN,  float fVegWidthIN, float fVegHeightIN, int iVegAreaWidthIN, int iGridSizeIN, int iTerrainID, int iOptionalSkipGrassMemblock);
+ void MakeVegetationGrid(int iVegPerMeshIN,  float fVegWidthIN, float fVegHeightIN, int iVegAreaWidthIN, int iGridSizeIN, int iTerrainID, int iOptionalSkipGrassMemblock, bool bBelowWater);
  void UpdateVegZone(bool bSuperFlat, float fX1, float fZ1, float fX2, float fZ2, int iTerrainID, float fSuperFlatHeight);
  void UpdateVegetation(bool bSuperFlat, float fViewPointX, float fViewPointZ, int iTerrainID, float fSuperFlatHeight, int iDynamicShadowImage);
  void UpdateBlitzTerrain(float fViewPointX, float fViewPointZ, int iTerrainID, int iDynamicShadowImage);


### PR DESCRIPTION
Added: Vegetation below water is now possible without clipping problems.
SetObjectTransparency(Obj,8) mode, to trigger render before water.

Added: setup.ini , (default) usegrassbelowwater=1 allow render of grass grid above/below waterline at the same time.

Fix: Distance to water object (0,600,0)-campos , prevented decals/transparent objects below water from displaying.

Editor: Changed editor water to use SetObjectTransparency(Obj,5) , so it act like in test game.

Fix: slow down physics fall speed and lower gravity when hitting water.
https://github.com/TheGameCreators/GameGuruRepo/issues/565

fix: Character Creator you cant see full list after installing additional assets.
https://github.com/TheGameCreators/GameGuruRepo/issues/410#issuecomment-506831070

