### PR TITLE
Improved winzone.lua - adds ability to lock Win Zones for Trigger Zone Activation

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/winzone.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/winzone.lua
@@ -1,11 +1,18 @@
 -- LUA Script - precede every function and global member with lowercase name of script
 
 function winzone_init(e)
+local winzone_name = ""
+end
+
+function winzone_init_name(e,name)
+winzone_name = name
 end
 
 function winzone_main(e)
  if g_Entity[e]['plrinzone']==1 then
-  JumpToLevelIfUsed(e)
+   if (winzone_name == "Win Zone" or g_Entity[e]['activated'] == 1) then
+    JumpToLevelIfUsed(e)
+   end
  end
 end
 


### PR DESCRIPTION
Updates Win Zones to allow for changing any Win Zone into an inactive state, that then requires activation from "ifused" fields in Trigger Zones or collectable entities.

This is a response to the feature request for #3618

Usage:
1. Place a winzone on the map
2. click on the win zone and change its name from "Win Zone" to a custom name
3. Place a trigger zone on the map
4. click on the trigger zone and put the custom name of the win zone in the ifused field of the trigger zone

This will make it so the player is required to reach the trigger zone before he can exit the level at the win zone.

This script update does not affect how Win Zones previously worked. If you keep them named "Win Zone" in the properties panel they will operate as normal. This also means that old projects will not be affected by this change. 