### PR TITLE
Fixes for Dying Effects (Heartbeat + Red Screen) 

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
@@ -1778,7 +1778,7 @@ function gameplayercontrol.control()
 	end
 
 	-- Screen REDNESS effect, and heartbeat, player is healthy, so fade away from redness
-	if ( g_PlayerHealth >= 100 ) then 
+	if ( g_PlayerHealth >= (g_gameloop_StartHealth/2) ) then
 		if ( GetGamePlayerControlRedDeathFog() > 0 ) then 
 			SetGamePlayerControlRedDeathFog(GetGamePlayerControlRedDeathFog() - GetElapsedTime())
 			if ( GetGamePlayerControlRedDeathFog() < 0 ) then SetGamePlayerControlRedDeathFog(0) end


### PR DESCRIPTION
Multiple Fixes and Changes to Player's Dying Effect trigger:

Fixes issue causing dying effect when the player was barely hurt:

Previously if the player was ever hurt, even by 1 point of damage, the player would act as if he was dying. The screen would go red and a heart-beat sound would play repeatedly until the player finds a health item or regenerates health. This used to occur instantly because the player's main script was set to cause this effect whenever the player's health was lower than 100. So for example if your health was 99, your game would assume the player is dying and cause a heart beat sound to play and flash the screen red. This change sets to check if player's health is less than 50% of its set maximum in the editor. Meaning less than 50/100 or less than 150/300 etc for examples.

Fixes 100 points being assumed as the maximum health for all games:

The original player script was set to assume the player's maximum health would always be 100 points. It was not using a percentage system either. So even if you set the players health to 1000 (for example) if you get injured the dying effect would only play if the players health was 99 out of 1000. This changes the solid "100" value to "g_gameloop_StartHealth".

In short, the "annoying" heartbeat and red-screen flashes will only ever occur if the player's health is drastically lower than its maximum meaning you will hear it only when you are actually dying or majorly hurt. A highly requested change in the community over the years.

We could in the future perhaps add an user option in the start marker to change what percentage the health must be lower than, to play the dying effects. For example replacing the 2 with a variable that can be controlled in the start marker in editor. So you can control how much to divide the maximum health by to determine percentage.

 g_PlayerHealth >= (g_gameloop_StartHealth/2) )

* Please note this change does not remove the player blood decals on screen, that occur when the player is hurt. It only changes when to run the dying/near death effects (heart-beat and red transparency on the overall screen).