### PR TITLE
Fixed Rotation Issue with Lightray Decal

### DIFF
--- a/GameGuru Core/GameGuru/Entity FPE Fixes/content/Files/entitybank/Model Pack 02/Decals/Light/Lightrays.fpe
+++ b/GameGuru Core/GameGuru/Entity FPE Fixes/content/Files/entitybank/Model Pack 02/Decals/Light/Lightrays.fpe
@@ -1,0 +1,29 @@
+
+;header
+desc          = Lightrays
+
+;visualinfo
+textured      = lightrays.dds
+effect        = effectbank\reloaded\decal_animate4.fx
+addhandle     = decalhandle.dds
+castshadow    = -1
+transparency  = 6
+
+;orientation
+model         = Decal.X
+defaultstatic = 0
+defaultheight = 50
+scale         = 300
+materialindex = 0
+cullmode      = 1
+collisionmode = 11
+
+;statistics
+strength      = 0
+explodable    = 0
+
+;ai
+aimain	      = default.lua
+
+
+


### PR DESCRIPTION
This fixes the issue with the lightray decal which is intended to be a light ray coming out from a window with no rotation. 

Unlike other decals, this decal when it rotates to always face the player, breaks the illusion that its emitting from a fixed position. By removing the decal facing lua in the FPE, this fixes the light-ray's casting direction.

Essentially it now operates as it did in FPSC, which is to add atmosphere to areas with windows.