### PR TITLE
Quick Fix for Blue Death Fog Bug

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameplayercontrol.lua
@@ -1803,7 +1803,7 @@ function gameplayercontrol.control()
 					end
 					SetGamePlayerControlHeartbeatTimeStamp(Timer()+1000)
 				end
-				ttTargetRed = 0.5 - (g_PlayerHealth/200.0)
+				ttTargetRed = 0.5 - (g_PlayerHealth/g_gameloop_StartHealth / 200.0)
 				if ( GetGamePlayerControlRedDeathFog() <= ttTargetRed ) then 
 					SetGamePlayerControlRedDeathFog(GetGamePlayerControlRedDeathFog() + GetElapsedTime())
 					if ( GetGamePlayerControlRedDeathFog() > ttTargetRed ) then SetGamePlayerControlRedDeathFog(ttTargetRed) end


### PR DESCRIPTION
This is fixes a new bug that was causing the red death fog to fall out of proportion to health, causing the screen to sometimes go blue.

line 1808 in gameplayercontrol.lua:

Previous:
ttTargetRed = 0.5 - (g_PlayerHealth/200.0)
Now:
ttTargetRed = 0.5 - (g_PlayerHealth/g_gameloop_StartHealth / 200.0)