### PR TITLE
GGC - Health.lua Update

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/health.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/health.lua
@@ -1,6 +1,14 @@
 -- LUA Script - precede every function and global member with lowercase name of script + '_main'
 -- Player Collects Health
 
+function health_init(e)
+local item_name
+end
+
+function health_init_name(e,name)
+item_name = name
+end
+
 function health_main(e)
  PlayerDist = GetPlayerDistance(e)
  if PlayerDist < 80 then

--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/health.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/health.lua
@@ -1,16 +1,17 @@
 -- LUA Script - precede every function and global member with lowercase name of script + '_main'
 -- Player Collects Health
 
-function health_init(e)
-end
-
 function health_main(e)
  PlayerDist = GetPlayerDistance(e)
- if PlayerDist < 80 and g_PlayerHealth > 0 then
-   Prompt("Collected health")
-   PlaySound(e,0)
-   AddPlayerHealth(e)
-   Destroy(e)
-   ActivateIfUsed(e)
+ if PlayerDist < 80 then
+	if g_PlayerHealth > 0 and g_PlayerHealth < g_gameloop_StartHealth then
+	Prompt("Collected "..item_name)
+	PlaySound(e,0)
+	AddPlayerHealth(e)
+	Destroy(e)
+	ActivateIfUsed(e)
+	else
+	Prompt("Your health is full.")
+	end
  end
 end


### PR DESCRIPTION
This GGC health.lua update will prevent health from exceeding the maximum player health set within the Player Start Marker, when collecting items such as medkits which should operate as health recovery items and healing items, rather than boosters.

This update also will prompt a message if the players health is already full.

(not sure if its possible to ignore the first commit and only accept the latest. As there is a mistake in the first commit and i'm unsure how to remove it. However the latest should override it.)