### PR TITLE
GGC - Proximity Mine Sound Issue Fix + IfUsed Feature Added

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/proximine.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/proximine.lua
@@ -28,22 +28,23 @@ function proximine_main(e)
 	 end
     end
    end
-   if PlayerDist<90 then 
+   if PlayerDist < 90 or g_Entity[e]['activated'] == 1 and proximine_started[e] == 0 then 
     proximine_started[e] = GetTimer(e)+2500
     PlaySound(e,0)
    end
   end
  end
- if proximine_started[e]>0 then
+ if proximine_started[e] > 0 then
   --if g_Entity[e] ~= nil then
   -- Prompt ( "timer=" .. GetTimer(e) .. " started=" .. proximine_started[e] .. " health = " .. g_Entity[e]['health'] )
   --end
   if GetTimer(e) > proximine_started[e] then
    SetEntityHealth(e,0)
-   proximine_started[e]=0
+   proximine_started[e]= -1
+   StopSound(e,0)
   end
  end
  if g_Entity[e]['health'] <= 0 then
-  StopSound(e)
+  StopSound(e,0)
  end
 end


### PR DESCRIPTION
This update will make it so the countdown timer sound effect doesn't ever play twice over. Which fixes a bug whereas the count down timer can sometimes be heard even after having exploded.

Additionally this update allows for the option of "IfUsed" on switches to detonate specified proximity mines on the map.