### PR TITLE
GGC - Added Jet Pack Fuel Script

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/jetpackfuel.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/jetpackfuel.lua
@@ -1,0 +1,24 @@
+-- LUA Script - precede every function and global member with lowercase name of script + '_main'
+-- Player Collects Jet Pack Fuel Tank
+
+
+
+function jetpackfuel_init(e)
+
+jetpackfuel = 0
+
+end
+
+function jetpackfuel_main(e)
+--Prompt ("Jetpack Fuel: "..jetpackfuel)
+--jetpackfuel = GetGamePlayerControlJetpackFuel ( ) 
+ PlayerDist = GetPlayerDistance(e)
+ if PlayerDist < 60 and g_PlayerHealth > 0 and g_PlayerThirdPerson == 0 then
+   Prompt("Collected jetpack fuel")
+   PlaySound(e,0)
+   jetpackfuel = GetGamePlayerControlJetpackFuel ()
+   SetGamePlayerControlJetpackFuel ( jetpackfuel + 500 )
+   Destroy(e)
+   ActivateIfUsed(e)
+ end
+end


### PR DESCRIPTION
This script when applied to an entity will turn the entity into a collectable item that will increase/re-fill the player's Jet Pack Fuel.


(I do have an entity associated with this I'd also like to include but am unsure of how to upload its FPE and BMP files to the Github without pushing other unnecessary items along with it.)