### PR TITLE
GGC - Update hurt.lua

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/hurt.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/hurt.lua
@@ -1,5 +1,5 @@
 -- LUA Script - precede every function and global member with lowercase name of script + '_main'
--- Detonate proximity mine
+
 
 function hurt_init(e)
  StartTimer(e)


### PR DESCRIPTION
This script for some reason had a comment of "Detonate proximity mine" although it is not associated with proximity mines.

The comment within the script has been removed in this update.