### PR TITLE
GGC - Fix/Feature Added - 3rd Person Player Ammo Collection

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/ammo.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/ammo.lua
@@ -6,7 +6,7 @@ end
 
 function ammo_main(e)
  PlayerDist = GetPlayerDistance(e)
- if PlayerDist < 60 and g_PlayerHealth > 0 and g_PlayerThirdPerson==0 then
+ if PlayerDist < 60 and g_PlayerHealth > 0 then
    Prompt("Collected ammo")
    PlaySound(e,0)
    AddPlayerAmmo(e)

--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/ammo_highlight.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/ammo_highlight.lua
@@ -7,10 +7,10 @@ end
 
 function ammo_highlight_main(e)
  PlayerDist = GetPlayerDistance(e)
- if PlayerDist < plr_highlight_ammo_range and g_PlayerHealth > 0 then
+ if PlayerDist < plr_highlight_ammo_range then
 	SetEntityHighlight(e,1) --1(red),2(pink),3(green),4(blue/green),5(gold)
  end
- if PlayerDist < 60 and g_PlayerHealth > 0 and g_PlayerThirdPerson==0 then
+ if PlayerDist < 60 and g_PlayerHealth > 0 then
    Prompt("Collected ammo")
    PlaySound(e,0)
    AddPlayerAmmo(e)


### PR DESCRIPTION
This update will allow for 3rd person player characters to collect ammo for their current weapon.

3rd person player character currently in Game Guru Classic only allows for one weapon to be used, however previously this also meant that the collection of ammo was being blocked. This prevented the player from being able to replenish ammo for the current and only weapon he/she could carry. This has now been fixed here.