### PR TITLE
GGC - Fixed Issue - Unable to Drown if Health Regen Enabled

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameloop.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/gameloop.lua
@@ -16,7 +16,7 @@ function gameloop.main()
   -- dont regen health if dead or at max health
   if g_PlayerLastHitTime > 0 then
    -- handle player health regeneration
-   if g_Time > g_PlayerLastHitTime + g_gameloop_RegenDelay then
+   if g_Time > g_PlayerLastHitTime + g_gameloop_RegenDelay and  GetGamePlayerControlInWaterState() < 3 then
     if g_Time > gameloop_RegenTickTime then
 	 gameloop_RegenTickTime = g_Time + g_gameloop_RegenSpeed
 	 newHealth = g_PlayerHealth + g_gameloop_RegenRate


### PR DESCRIPTION
Fixes an issue of which would prevent the player from drowning if health regeneration was enabled. Better to have this as a baseline. Since it essentially voided the player's ability to drown. 