### PR TITLE
GGC - New Lua Command - MoveDown(e,v)

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
@@ -633,6 +633,9 @@ end
 function MoveUp(e,v)
  SendMessageF("moveup",e,v);
 end
+function MoveDown( e, v )
+MoveUp( e, -v )
+end
 function MoveForward(e,v)
  SendMessageF("moveforward",e,v);
 end


### PR DESCRIPTION
A new Lua command has been created called: MoveDown(e,v)

This is to compliment the existing commands MoveUp(e,v), MoveForward(e,v) and MoveBackward(e,v)

(Commonly users just getting into GGC with Lua ask why MoveDown does not work. This is because it does not exist.)