### PR TITLE
GGC - New Lua Command - GetFileExists(filename)

### DIFF
--- a/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
+++ b/GameGuru Core/GameGuru/Shaders and Scripts/scriptbank/global.lua
@@ -339,6 +339,16 @@ function PromptLocalForVR(e,str,vrmode)
  SendMessageS("promptlocalforvr",e,str);
 end
 
+function GetFileExists(filename)
+    local file = io.open(filename, "r")
+    if file then
+        file:close()
+        return 1
+    else
+        return 0
+    end
+end
+
 function SetFogNearest(v)
  SendMessageF("setfognearest",v)
 end


### PR DESCRIPTION
GetFileExists(filename) added to global.lua allows you to check if a file of any kind exists. 

This is also good for preventing GGC crashes for when attempting to load images/sprites, audio and video as users can use it to check if a file exists before attempting to load them. It has a wide range of possibilities.  It can also be used to check if certain Lua scripts exists or any other file type. It scans from within "files" root.

Example:

if GetFileExists("scriptbank/example.lua") == 1 then
    Prompt("File exists!")
else
    Prompt("File does not exist!")
end
